### PR TITLE
Implement Get countries with jwt

### DIFF
--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -1,0 +1,24 @@
+import jwt from 'jsonwebtoken';
+
+const auth = (req, res, next) => {
+  const token =
+  req.headers['x-access-token'] || req.body.token || req.query.token;
+  if (!token) {
+    return res.status(401).json({
+      status: 'Fail',
+      message: 'No token provided.'
+    });
+  }
+  jwt.verify(token, 'secret', (err, decoded) => {
+    if (err) {
+      return res.status(500).json({
+        status: 'Fail',
+        message: err.message
+      });
+    }
+    req.decoded = decoded;
+    next();
+  });
+};
+
+export default auth;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,42 +1,51 @@
 import express from 'express';
 import jwt from 'jsonwebtoken';
+import auth from '../middlewares/auth'
 
 const router = express.Router();
+let countries = [];
 
 // login user route
-router.post(
-    '/login', (req, res) => {
-        const { username, password } = req.body;
+router.post('/login', (req, res) => {
+    const { username, password } = req.body;
 
-        if (username === 'admin') {
-            if (password === 'admin') {
+    if (username === 'admin') {
+        if (password === 'admin') {
 
-                const token = jwt.sign(
-                    {
-                      id: 'admin1',
-                      username: username,
-                    },
-                    'secret',
-                    { expiresIn: 86400 }
-                  );
+            const token = jwt.sign(
+                {
+                    id: 'admin1',
+                    username: username,
+                },
+                'secret',
+                { expiresIn: 86400 }
+            );
 
-                return res.status(200).json({
-                    status: 'Success',
-                    message: 'Login successful',
-                    token
-                });
-            }
-            return res.status(401).json({
-                status: 'Fail',
-                message: 'Wrong Password'
-            })
+            return res.status(200).json({
+                status: 'Success',
+                message: 'Login successful',
+                token
+            });
         }
         return res.status(401).json({
             status: 'Fail',
-            message: 'Invalid username'
+            message: 'Wrong Password'
         })
+    }
+    return res.status(401).json({
+        status: 'Fail',
+        message: 'Invalid username'
+    })
 
-    });
+});
+
+router.get('/countries', auth, (req, res) => {
+    return res.status(200).json({
+        status: 'Success',
+        countries
+    })
+    
+})
 
 export default router;
 


### PR DESCRIPTION
#### What does this PR do?
- Implement get countries endpoint.
- Add middleware to verify JWT.
#### Description of Task to be completed?
- Create get countries controller.
#### How should this be manually tested?
- Clone and setup this repo locally.
- Hit ```localhost:8080/countries``` with a  GET request using Postman
- Login with Postman with username and password as ```admin```
- Add the token using ```x-access-token``` header and ```longJWTasproperty```.

#### Any background context you want to provide?
- This endpoint is protected, You'll need to login to generate a token.
#### Screenshots (if appropriate)
![ddd](https://user-images.githubusercontent.com/19694117/51295489-2abbd180-1a18-11e9-96eb-08bd8ef84da6.jpg)
#### Questions:
N/A
